### PR TITLE
Upgrade xml2json so node-expat builds under 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "optimist": "~0.3.x"
     },
     "dependencies": {
-        "xml2json": "0.3.2"
+        "xml2json": "^0.6.1"
     },
     "main": "./ofx.js",
     "directories":  {},


### PR DESCRIPTION
This is a trivial change to allow `ofx` to be installed on node v0.12.0+. See node-xmpp/node-expat#112 and buglabs/node-xml2json#57