### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,7 @@
         "url" : "http://github.com/appsattic/ofx/issues",
         "mail" : "chilts@appsattic.com"
     },
-    "licenses": [{
-        "type": "MIT",
-        "url": "http://github.com/appsattic/ofx/raw/master/LICENSE"
-    }],
+    "license": "MIT",
     "keywords": [
         "ofx", "open financial exchange", "bank", "banking", "export"
     ],


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
