### PR TITLE
Fix #11

### DIFF
--- a/ofx.js
+++ b/ofx.js
@@ -18,7 +18,7 @@ function parse(data) {
     const ofx = data.split('<OFX>', 2);
 
     // firstly, parse the headers
-    const headerString = ofx[0].split(/\r?\n/);
+    const headerString = ofx[0].split(/\r|\n|\r\n/);
     const header = {};
     headerString.forEach((attrs) => {
         const headAttr = attrs.split(/:/,2);


### PR DESCRIPTION
Fixes the issue raised at #11 where single `\r`'s break the header parsing.